### PR TITLE
Use mise to manage tools

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -10,3 +10,18 @@ postinstall = "bun install"
 
 [env]
 _.path = "node_modules/.bin"
+
+[tasks.start]
+run = "bun game"
+
+[tasks.build]
+run = "swc src -d game"
+
+[tasks.dev]
+run = "bun build -w"
+
+[tasks.prepack]
+run = "bun build"
+
+[tasks.release]
+run = "bunx auto shipit"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,12 @@
+[tools]
+bun = "1.2.22"
+
+[settings]
+experimental = true
+pin = true
+
+[hooks]
+postinstall = "bun install"
+
+[env]
+_.path = "node_modules/.bin"


### PR DESCRIPTION
# Pull Request Description

## Changes
- Added mise.toml to configure Bun environment and hooks.
- Set Bun version to 1.2.22 and enabled experimental features.
- Pinned dependencies and added postinstall hook to run `bun install`.
- Configured environment path to include local node_modules binaries.
- Ported npm scripts to mise tasks.