### PR TITLE
Ignore lock files from npm, yarn, pnpm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 game
 layouts.monopic
 yarn-error.log
+*-lock.json


### PR DESCRIPTION
This repo uses bun but sometimes LLMs will use npm to install packages 
which leads to a stray lockfile hanging out. I just want to ignore that 
lockfile.